### PR TITLE
Bump py-allspice version and document skip in bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ By default:
 - Grouped values are separated by a comma.
 - Grouped values do not allow duplicates.
 
+#### Skip in output
+
+If you need an attribute to just filter, sort or group by, but not show in the
+BOM output, you can use the `skip_in_output` attribute.
+
+```yaml
+columns:
+  - name: "BOM Ignore"
+    part_attributes:
+      - "BOM_IGNORE"
+    remove_rows_matching: ".*"
+    skip_in_output: true
+```
+
 ## Group By
 
 You can also group lines by a column value. The most common is `_part_id`. You

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-py-allspice==3.4.0
+py-allspice==3.5.0
 pyyaml~=6.0


### PR DESCRIPTION
Since this doesn't involve patching this action, this will be tagged as v0.5.1 and won't require any user changes in their workflows.