### PR TITLE
Update py-allspice to 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-py-allspice==3.6.0
+py-allspice~=3.7.0
 pyyaml~=6.0


### PR DESCRIPTION
Using a compatible specifier so it picks all 3.7 releases if we make any bugfixes.