### PR TITLE
feat: enable new altium renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following steps to your actions:
   uses: actions/checkout@v3
 
 - name: Generate BOM
-  uses: https://hub.allspice.io/Actions/generate-bom@v0.10
+  uses: https://hub.allspice.io/Actions/generate-bom@v0.11
   with:
     # The path to the project file in your repo.
     # .PrjPcb for Altium, .DSN for OrCad, .CPM for DeHDL, .SDAX for System Capture.
@@ -299,3 +299,4 @@ setting the `auth_token` input.
     variant: "LITE"
     auth_token: ${{ secrets.ALLSPICE_AUTH_TOKEN }}
 ```
+

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,11 @@ inputs:
       token for the run is used.
     required: false
     default: ${{ github.token }}
+  use_legacy_altium_renderer:
+    description: >
+      Force use of the legacy Altium renderer in case the new one is causing issues.
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -64,6 +69,8 @@ runs:
     - "${{ github.workspace}}/${{ inputs.output_file_name }}"
     - "--log-level"
     - ${{ inputs.log_level }}
+    - "--use-legacy-altium-renderer"
+    - ${{ inputs.use_legacy_altium_renderer }}
     - ${{ github.repository }}
     - ${{ inputs.source_path }}
   env:

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -80,6 +80,11 @@ if __name__ == "__main__":
         help="The log level for the logger. Defaults to INFO.",
         default="INFO",
     )
+    parser.add_argument(
+        "--use-legacy-altium-renderer",
+        help="Force use of the legacy Altium renderer in case the new one is causing issues.",
+        default="false",
+    )
 
     args = parser.parse_args()
 
@@ -139,6 +144,9 @@ if __name__ == "__main__":
             allspice_hub_url=args.allspice_hub_url,
             log_level=args.log_level.upper(),
         )
+
+    if args.use_legacy_altium_renderer == "true":
+        allspice.use_new_schdoc_renderer = False
 
     allspice.logger.addHandler(handler)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-py-allspice~=3.12.1
+py-allspice>=4.0.0b1
 pyyaml~=6.0


### PR DESCRIPTION
- Pulls a new version of `py-allspice`
- Adds a flag for disabling the Altium renderer used in `py-allspice`