### PR TITLE
docs: document DxDesigner .prj support (ID-4318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Generate BOM for E-CAD Projects
 
-Generate a BOM output file for Altium, OrCAD, DeHDL or System Capture projects on
+Generate a BOM output file for Altium, OrCAD, DeHDL, System Capture or DxDesigner projects on
 AllSpice Hub using
 [AllSpice Actions](https://learn.allspice.io/docs/actions-cicd).
 
@@ -17,7 +17,7 @@ Add the following steps to your actions:
   uses: https://hub.allspice.io/Actions/generate-bom@v0.11
   with:
     # The path to the project file in your repo.
-    # .PrjPcb for Altium, .DSN for OrCad, .CPM for DeHDL, .SDAX for System Capture.
+    # .PrjPcb for Altium, .DSN for OrCad, .CPM for DeHDL, .SDAX for System Capture, .PRJ for DxDesigner.
     source_path: Archimajor.PrjPcb
     # [optional] A path to a YAML file mapping columns to the component
     # attributes they are from.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: >
   Generate a BOM for the project using py-allspice and attach it as an artifact
   to the run.
 
-  Works for Altium, OrCAD, DeHDL and System Capture projects.
+  Works for Altium, OrCAD, DeHDL, System Capture and DxDesigner projects.
 
 inputs:
   source_path:
@@ -13,7 +13,8 @@ inputs:
       - A .PrjPcb file for Altium projects.
       - A .DSN file for OrCAD projects.
       - An .SDAX file for System Capture projects.
-      - A .CPM file for DeHDL projects
+      - A .CPM file for DeHDL projects.
+      - A .PRJ file for DxDesigner projects.
     required: true
   output_file_name:
     description: "Name of the output file"
@@ -31,8 +32,8 @@ inputs:
   variant:
     description: >
       The variant of the project to generate the BOM for. If not present, the
-      BOM will be generated for the default variant. Not supported for OrCAD
-      or DeHDL projects.
+      BOM will be generated for the default variant. Not supported for OrCAD,
+      DeHDL, or DxDesigner projects.
     default: ""
   log_level:
     description: >

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -32,8 +32,8 @@ if __name__ == "__main__":
         help=(
             "The path to the source file used to generate the BOM. This should be "
             "a .PrjPcb file for Altium projects, a .DSN file for OrCAD projects, "
-            "a .CPM file for DeHDL projects, or a .SDAX file for System Capture "
-            "projects."
+            "a .CPM file for DeHDL projects, a .SDAX file for System Capture "
+            "projects, or a .PRJ file for DxDesigner projects. "
             "Example: 'Archimajor.PrjPcb', 'Schematics/Beagleplay.dsn'."
         ),
     )
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         "--variant",
         help=(
             "The variant of the project to generate the BOM for. If not present, the BOM will be "
-            "generated for the default variant. This is not used for OrCAD or DeHDL projects."
+            "generated for the default variant. This is not used for OrCAD, DeHDL, or DxDesigner projects."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Closes [ID-4318]

## Summary
  
Documents Siemens/Mentor Graphics **DxDesigner** (`.prj`) support in the generate-bom Action. Companion to the [py allspice PR](https://github.com/AllSpiceIO/py-allspice/pull/301) that implements it.

## What changed (docs only)
- `entrypoint.py` — `source_file` and `--variant` `--help` text now list DxDesigner `.prj` (also fixed a missing space in the `source_file` help)
- `README.md` — added `.PRJ` / DxDesigner to the supported-tools list

## Validation
Ran the Action's `entrypoint.py` end-to-end against the open-source Minnowboard Turbot project on a local Hub (using the py-allspice DxDesigner branch): produced a **905-row BOM** (the `CPU1` SoC's 13 symbols collapsed to one) with **89 parts correctly flagged `DNI`** via a `Populate` column.

## ⚠️  Release sequencing
The Action only actually supports `.prj` once py-allspice **with the DxDesigner changes is published**. `requirements.txt` (`py-allspice>=4.0.0`) will pull it automatically on the next image build, so no requirements change is needed — but **don't release this ahead of the py-allspice release**, or the docs will be ahead of reality.